### PR TITLE
Subcompiler work

### DIFF
--- a/carpet/cg/compiler.py
+++ b/carpet/cg/compiler.py
@@ -346,6 +346,15 @@ class Compiler:
 
             res.conditions = new_conditions
             new_asts += [res]
+        elif self.is_callable(ast):
+            # Ok, we need to add each of the parameters to
+            # the local declarations
+            for param in ast.parameters:
+                pass
+
+            for b in ast.body.progn:
+                pass
+            new_asts += [ast]
         elif type(ast) == CoastOpCallAST or type(ast) == CoastFNCallAST:
             (lifted, newcall) = self.lift_call_with_case(ast)
             # NOTE we hve to actually walk over lifted and
@@ -366,12 +375,16 @@ class Compiler:
                 # we have an operator, check if it's one we know about
                 pass
 
+            # NOTE this is a stub
+            for d in ast.data:
+                pass
+
             # XXX and here we need to check all variables to see if we
             # know about those as well...
         else:
             # here, we need to iterate over all the members anyway, and make sure they're
             # all defined...
-            pass
+            new_asts += [ast]
         return new_asts
 
     def is_callable(self, fn):

--- a/carpet/cg/compiler.py
+++ b/carpet/cg/compiler.py
@@ -343,6 +343,7 @@ class Compiler:
 
             res.conditions = new_conditions
             new_asts += [res]
+
         elif self.is_callable(ast):
             # Ok, we need to add each of the parameters to
             # the local declarations
@@ -352,6 +353,20 @@ class Compiler:
             for b in ast.body.progn:
                 pass
             new_asts += [ast]
+
+        elif type(ast) == CoastBlockAST:
+
+            # XXX blocks
+            # blocks themselves introduce a new scope...
+            # so should we create a copy of env, and
+            # then use *that* for the sub compilation?
+            # likely we aren't here directly, but that
+            # *would* mean that the caller wouldn't have
+            # to manage how we handle environments...
+            block_env = env.copy()
+            for b in ast.progn:
+                self.sub_compile(b, block_env)
+
         elif type(ast) == CoastOpCallAST or type(ast) == CoastFNCallAST:
             (lifted, newcall) = self.lift_call_with_case(ast)
             # NOTE we hve to actually walk over lifted and

--- a/carpet/cg/compiler.py
+++ b/carpet/cg/compiler.py
@@ -347,25 +347,42 @@ class Compiler:
         elif self.is_callable(ast):
             # Ok, we need to add each of the parameters to
             # the local declarations
+            fn_env = env.copy()
+            body_asts = []
             for param in ast.parameters:
+                #fn_env.declarations[param.ident
                 pass
 
             for b in ast.body.progn:
-                pass
+                body_asts += self.sub_compile(b, fn_env)
+
             new_asts += [ast]
 
         elif type(ast) == CoastBlockAST:
 
-            # XXX blocks
+            # NOTE blocks
             # blocks themselves introduce a new scope...
             # so should we create a copy of env, and
             # then use *that* for the sub compilation?
             # likely we aren't here directly, but that
             # *would* mean that the caller wouldn't have
             # to manage how we handle environments...
+            #
+            # oooo but how to make that work for function
+            # parameters? those actually need to be defined...
+            # but if you think about it, there's no *real*
+            # harm in yet another frame here, other than the
+            # memory consumption... ok, so what we also can
+            # do is what I do above, which is to elide the
+            # call for the block into the `fn` check itself;
+            # if we ever change how we compile blocks, that
+            # will have to change, but for now it should be
+            # fine
             block_env = env.copy()
+            new_progn = []
             for b in ast.progn:
-                self.sub_compile(b, block_env)
+                new_progn += self.sub_compile(b, block_env)
+            new_block = CoastBlockAST(new_progn)
 
         elif type(ast) == CoastOpCallAST or type(ast) == CoastFNCallAST:
             (lifted, newcall) = self.lift_call_with_case(ast)

--- a/carpet/cg/compiler.py
+++ b/carpet/cg/compiler.py
@@ -271,16 +271,13 @@ class Compiler:
                 tmp = []
 
                 if self.is_self_tail_call(ast.name, ast.value):
-                    print("274?")
                     ast.value.self_tail_call = True
                     shadowed_fn = self.generate_shadows_self_tail_call(ast.name, ast.value)
                     tmp = self.sub_compile(shadowed_fn, env.copy())
                     new_assign = CoastAssignAST(ast.name, tmp[0])
                     new_asts += [new_assign]
                 else:
-                    print("281?")
                     tmp = self.sub_compile(ast.value, env.copy())
-                print("%%tmp: ", tmp)
                 new_assign = CoastAssignAST(ast.name, tmp[0])
                 new_asts += [new_assign]
                 # XXX interesting point: do we do this here, and potentially modify the
@@ -415,7 +412,13 @@ class Compiler:
                     "string-sort", "compare", "char-code", "char-chr",
                     "char-escaped", "char-lowercase", "char-uppercase",
                     "char-compare", "random-int", "random-float", "random-int-range",
-                    "random-bool", "random-choice"]
+                    "random-bool", "random-choice", "stream-init", "stream-iter",
+                    "stream-map", "stream-next", "option-get", "open-in", "open-out",
+                    "close", "+", "-", "*", "/", "%", "^", "&", "$", "!", "@", "!=", "<>",
+                    "!", "not", "<<", ">>", "|", "|>", "<|", "||", "&&", "log-shr", "log-shl",
+                    "log-and", "log-or", "log-not", "print_endline", "print", "char-escape",
+                    "int_of_string", "string_of_int", "string_of_float", "string_of_bool"]
+
         return fn.identvalue in basislib
 
     def is_accessor(self, fn):

--- a/carpet/cg/compiler.py
+++ b/carpet/cg/compiler.py
@@ -401,7 +401,8 @@ class Compiler:
                     raise CoastalCompilerError("undefined function: \"{0}\"".format(ast.fn.identvalue), 0)
                 # XXX 14DEC2022 ok and next we have to iterate over the data...
             else:
-                # we have an operator, check if it's one we know about
+                if not self.is_basis_fn(ast.op) and ast.op.identvalue not in env.functions:
+                    raise CoastalCompilerError("undefined operator: \"{0}\"".format(ast.op.identvalue), 0)
                 pass
 
             # NOTE this is a stub

--- a/carpet/util/spaghetti.py
+++ b/carpet/util/spaghetti.py
@@ -18,7 +18,10 @@ class SpaghettiStack:
         if add_depth:
             ret = SpaghettiStack(None)
             ret.frames = [x for x in self.frames]
-            ret.frames.append({})
+            if type(self.frames[0]) is list:
+                ret.frames.append([])
+            else:
+                ret.frames.append({})
             ret.depth = self.depth + 1
             return ret
         else:
@@ -86,6 +89,19 @@ class SpaghettiStack:
             frame = self.frames[fidx]
             ret.append(frame.items())
         return ret
+
+    def __ior__(self, rhs):
+        if type(self.frames[0]) is dict:
+            return self.frames[-1] | rhs
+        else:
+            raise NotImplemented("__ior__ only works on dictionary frames")
+
+    def __iadd__(self, rhs):
+        if type(self.frames[0]) is list:
+            self.frames[-1] += rhs
+            return self
+        else:
+            raise NotImplemented("__iadd__ only works on list frames")
 
 # Just a simple helper to model how we actually use SpaghettiStacks in code really
 # Also makes it easier when calling the sub-compiler, because instead of passing in

--- a/carpet/util/spaghetti.py
+++ b/carpet/util/spaghetti.py
@@ -101,7 +101,7 @@ class EnvironmentFrame:
         self.modules = SpaghettiStack(modules)
         self.depth = 0
 
-    def copy():
+    def copy(self):
         ret = EnvironmentFrame(self.declarations.copy(),
                                self.variables.copy(),
                                self.functions.copy(),


### PR DESCRIPTION
This basically shims the sub-compiler into the Compiler object itself, but doesn't force it's use. The sub-compiler has a bunch of interesting things that we may wish to refactor into the compiler proper:

1. spaghetti stacks instead of individual dicts/lists
2. environment frames, which are themselves spaghetti stacks of the various environment members
3. checks to see if operators are defined
4. basic checking of `case` then blocks

This is good enough to merge now, but definitely think we probably want to refactor all of this code: make *one* compiler that walks through and can do all of these checks, similar to how
the sub-compiler itself works. Since the shims are there, we literally could just flip the switch and make this the compiler; more work needs to be done on `case` & `fn` forms (in fact, all callables), and `impl` & `sig` aren't there yet, but it's an interesting start.